### PR TITLE
Initialize the route change enum correctly

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -401,12 +401,15 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     @objc
     func audioRouteChanged(notification: NSNotification!) {
-        if let userInfo = notification.userInfo {
-            let reason: AVAudioSession.RouteChangeReason! = userInfo[AVAudioSessionRouteChangeReasonKey] as? AVAudioSession.RouteChangeReason
-            //            let previousRoute:NSNumber! = userInfo[AVAudioSessionRouteChangePreviousRouteKey] as? NSNumber
-            if reason == .oldDeviceUnavailable, let onVideoAudioBecomingNoisy {
-                onVideoAudioBecomingNoisy(["target": reactTag as Any])
-            }
+        guard let userInfo = notification.userInfo,
+              let reasonValue = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt,
+              // let previousRouteValue: UInt = userInfo[AVAudioSessionRouteChangePreviousRouteKey] as? UInt
+              let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue) else {
+            return
+        }
+
+        if reason == .oldDeviceUnavailable, let onVideoAudioBecomingNoisy {
+            onVideoAudioBecomingNoisy(["target": reactTag as Any])
         }
     }
 


### PR DESCRIPTION
This addresses these issues:
- https://github.com/fpm-git/Floatplane-Mobile/issues/367
- https://github.com/TheWidlarzGroup/react-native-video/issues/4295

The `onVideoAudioBecomingNoisy` handler wasn't being called becuase this line resulted in `reason: nil`.

```swift
let reason: AVAudioSession.RouteChangeReason! = userInfo[AVAudioSessionRouteChangeReasonKey] as? AVAudioSession.RouteChangeReason
```

The correct way to get the `AVAudioSession.RouteChangeReason` is to initialize it with the raw value provided by `userInfo`, as confirmed by [Apple documentation](https://developer.apple.com/documentation/avfaudio/responding-to-audio-route-changes#Respond-to-route-changes).

I've confirmed with print statements that the `reason` is no longer nil and the handler is called when headphones are unplugged during playback.

I also updated the commented-out line for consistency. I'll submit a PR to the original repo once this is tested and approved for our fork.

### Testing

Connect a physical iPhone to Xcode via wifi and plug in USB-C headphones to the iPhone. In package.json for Floatplane, change the source branch for this package to match this PR's branch, then do a clean install of dependencies. Once installed, build and run the app on your iPhone via Xcode.
